### PR TITLE
Resolve character errors in FAQ

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -130,9 +130,9 @@
             <p style="font-weight:bold;">What is a hackathon?</p>
             <p>Hoya Hacks is a 36-hour event at Georgetown University that brings together super smart students to build something cool. We provide the resources for you to succeed, no matter your skill level!</p>
             <p style="font-weight:bold;">Who can attend?</p>
-            <p>Hoya Hacks is open to any undergraduate at any college. Non-Georgetown students must be at least 18 years old. Unfortunately, at this time high school students (who are under 18) can’t attend.</p>
+            <p>Hoya Hacks is open to any undergraduate at any college. Non-Georgetown students must be at least 18 years old. Unfortunately, at this time high school students (who are under 18) can't attend.</p>
             <p style="font-weight:bold;">Do I need to know how to code?</p>
-            <p>Students of all skill levels are encouraged to attend, even if you’ve never written a line of code. We’re prepared to teach you everything you need to learn right here while also supporting the most experienced hackers.</p>
+            <p>Students of all skill levels are encouraged to attend, even if you've never written a line of code. We're prepared to teach you everything you need to learn right here while also supporting the most experienced hackers.</p>
             <p style="font-weight:bold;">Is the event free?</p>
             <p>Yes, absolutely! Say thanks to our amazing sponsors. We will provide food, prizes, swag, and crazy fun activities.</p>
             <p style="font-weight:bold;">What should I bring?</p>


### PR DESCRIPTION
The curly apostrophes cause my browser to choke (see screenshot). I'm guessing this is a common problem around HTML encoding not unique to updated Chrome.

Replaced them with `'`! Hopefully will make everything look cleaner.

<img width="475" alt="screen shot 2016-09-10 at 10 18 35 am" src="https://cloud.githubusercontent.com/assets/4955943/18412349/c403c398-7740-11e6-9ca9-ae1204963a0f.png">
